### PR TITLE
feat: T19 死亡頁面

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import RegisterPage from './pages/RegisterPage';
 import InitPage from './pages/InitPage';
 import GamePage from './pages/GamePage';
 import FeedPage from './pages/FeedPage';
+import DeathPage from './pages/DeathPage';
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const token = localStorage.getItem('token');
@@ -20,19 +21,10 @@ function App() {
         <Route path="/init" element={<PrivateRoute><InitPage /></PrivateRoute>} />
         <Route path="/game" element={<PrivateRoute><GamePage /></PrivateRoute>} />
         <Route path="/feed" element={<PrivateRoute><FeedPage /></PrivateRoute>} />
-        <Route path="/death" element={<PrivateRoute><Placeholder page="死亡" /></PrivateRoute>} />
+        <Route path="/death" element={<PrivateRoute><DeathPage /></PrivateRoute>} />
         <Route path="*" element={<Navigate to="/login" replace />} />
       </Routes>
     </div>
   );
 }
-
-function Placeholder({ page }: { page: string }) {
-  return (
-    <div className="flex min-h-screen items-center justify-center">
-      <h1 className="text-lg font-pixel text-brown">{page}</h1>
-    </div>
-  );
-}
-
 export default App;

--- a/frontend/src/pages/DeathPage.tsx
+++ b/frontend/src/pages/DeathPage.tsx
@@ -1,0 +1,89 @@
+import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { useQueryClient } from '@tanstack/react-query';
+
+export default function DeathPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [params] = useSearchParams();
+
+  const petName = params.get('petName') ?? '電子雞';
+  const totalFeedings = Number(params.get('totalFeedings') ?? 0);
+
+  // 禁止返回上一頁
+  useEffect(() => {
+    const block = () => {
+      window.history.pushState(null, '', window.location.href);
+    };
+    window.history.pushState(null, '', window.location.href);
+    window.addEventListener('popstate', block);
+    return () => window.removeEventListener('popstate', block);
+  }, []);
+
+  const handleAdopt = () => {
+    // 清除 pet 相關快取
+    queryClient.removeQueries({ queryKey: ['pet'] });
+    navigate('/init', { replace: true });
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-[#F5E6D3] px-4">
+      {/* 墓碑區 */}
+      <motion.div
+        initial={{ opacity: 0, y: 30 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8 }}
+        className="flex flex-col items-center"
+      >
+        <span className="text-8xl drop-shadow-lg">🪦</span>
+
+        <motion.p
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.6, duration: 0.8 }}
+          className="mt-6 font-pixel text-sm text-brown-dark"
+        >
+          {petName} 已經永遠離開了…
+        </motion.p>
+
+        <motion.p
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 1.0, duration: 0.8 }}
+          className="mt-3 font-pixel text-[10px] text-brown-light"
+        >
+          曾被餵食 {totalFeedings} 次
+        </motion.p>
+
+        <motion.p
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 1.4, duration: 0.8 }}
+          className="mt-2 font-pixel text-[10px] text-brown-light"
+        >
+          感謝你的陪伴 🕊️
+        </motion.p>
+      </motion.div>
+
+      {/* 分隔線 */}
+      <motion.div
+        initial={{ scaleX: 0 }}
+        animate={{ scaleX: 1 }}
+        transition={{ delay: 1.8, duration: 0.6 }}
+        className="my-8 h-[2px] w-48 bg-brown-light opacity-40"
+      />
+
+      {/* 領養新電子雞按鈕 */}
+      <motion.button
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 2.2, duration: 0.6 }}
+        onClick={handleAdopt}
+        className="border-4 border-orange-dark bg-orange px-6 py-4 font-pixel text-xs text-white transition-all hover:-translate-y-0.5 hover:bg-orange-dark hover:shadow-lg active:translate-y-0"
+      >
+        🌱 領養新電子雞
+      </motion.button>
+    </div>
+  );
+}


### PR DESCRIPTION
## T19 死亡頁面

### 完成項目

- ✅ `DeathPage.tsx`：悼念頁面
- ✅ `App.tsx`：/death 路由更新

### 功能細節
- 🪦 超大墓碑 emoji + 深色暖底淡入動畫
- 從 URL query params 讀取 petName + totalFeedings
- popstate 事件攔截，禁止瀏覽器上一頁
- 「🌱 領養新電子雞」按鈕：清除快取後導向 /init

### 驗收條件
- [x] 死亡時正確跳轉（/death?petName=X&totalFeedings=Y）
- [x] 顯示悼念訊息
- [x] 可重新領養新電子雞

Closes #19