### PR TITLE
feat: T24 PWA 離線支援

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,8 @@
     "typescript": "^5.7.2",
     "vite": "^6.0.3",
     "vite-plugin-pwa": "^0.21.1",
-    "vitest": "^2.1.8"
+    "vitest": "^2.1.8",
+    "workbox-routing": "^7.4.0",
+    "workbox-strategies": "^7.4.0"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
@@ -5,6 +6,7 @@ import InitPage from './pages/InitPage';
 import GamePage from './pages/GamePage';
 import FeedPage from './pages/FeedPage';
 import DeathPage from './pages/DeathPage';
+import OfflineBanner from './components/OfflineBanner';
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const token = localStorage.getItem('token');
@@ -13,8 +15,22 @@ function PrivateRoute({ children }: { children: React.ReactNode }) {
 }
 
 function App() {
+  const [isOffline, setIsOffline] = useState(!navigator.onLine);
+
+  useEffect(() => {
+    const goOffline = () => setIsOffline(true);
+    const goOnline = () => setIsOffline(false);
+    window.addEventListener('offline', goOffline);
+    window.addEventListener('online', goOnline);
+    return () => {
+      window.removeEventListener('offline', goOffline);
+      window.removeEventListener('online', goOnline);
+    };
+  }, []);
+
   return (
     <div className="min-h-screen bg-cream text-brown-dark">
+      {isOffline && <OfflineBanner />}
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { savePetToCache, getPetFromCache, getLastSyncTime } from '../services/offlineStorage';
 
 const client = axios.create({
   baseURL: '/api',
@@ -14,12 +15,35 @@ client.interceptors.request.use((config) => {
 });
 
 client.interceptors.response.use(
-  (res) => res,
+  (res) => {
+    // 當 GET /pet 成功時，自動存入 localStorage
+    if (res.config.method === 'get' && res.config.url === '/pet' && res.data) {
+      savePetToCache(res.data);
+    }
+    return res;
+  },
   (error) => {
     if (error.response?.status === 401) {
       localStorage.removeItem('token');
       window.location.href = '/login';
     }
+
+    // 網路錯誤時，嘗試從 localStorage 取出 cached pet
+    if (!error.response && error.config?.method === 'get' && error.config?.url === '/pet') {
+      const cached = getPetFromCache();
+      if (cached) {
+        return {
+          data: cached,
+          status: 200,
+          statusText: 'OK (offline cache)',
+          headers: {},
+          config: error.config,
+          _fromCache: true,
+          _lastSync: getLastSyncTime(),
+        };
+      }
+    }
+
     return Promise.reject(error);
   },
 );

--- a/frontend/src/components/OfflineBanner.tsx
+++ b/frontend/src/components/OfflineBanner.tsx
@@ -1,0 +1,14 @@
+import { getLastSyncTime } from '../services/offlineStorage';
+
+export default function OfflineBanner() {
+  const lastSync = getLastSyncTime();
+  const formatted = lastSync
+    ? new Date(lastSync).toLocaleString('zh-TW')
+    : '未知';
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-50 border-b-2 border-orange-500 bg-yellow-200 px-4 py-2 text-center font-pixel text-[10px] text-orange-800 sm:text-xs">
+      📴 目前離線，最後同步：{formatted}
+    </div>
+  );
+}

--- a/frontend/src/pages/GamePage.tsx
+++ b/frontend/src/pages/GamePage.tsx
@@ -7,6 +7,7 @@ import PixelSprite from '../components/PixelSprite';
 import PixelButton from '../components/PixelButton';
 import NotificationPrompt from '../components/NotificationPrompt';
 import usePushNotification from '../hooks/usePushNotification';
+import { getPetFromCache } from '../services/offlineStorage';
 
 /** 距離上次餵食是否超過 1.5 小時 */
 function isHungry(lastFedAt: string): boolean {
@@ -51,8 +52,21 @@ export default function GamePage() {
     }
   }, [pet, checkAndNotify]);
 
-  // --- 載入中 ---
+  // --- 載入中：離線時嘗試使用快取 ---
   if (isLoading) {
+    if (!navigator.onLine) {
+      const cached = getPetFromCache();
+      if (cached) {
+        return <OfflineGameView pet={cached} navigate={navigate} />;
+      }
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-cream">
+          <p className="font-pixel text-brown text-center text-xs px-4">
+            📴 無網路且無快取資料，請連線後再試
+          </p>
+        </div>
+      );
+    }
     return (
       <div className="flex min-h-screen items-center justify-center bg-cream">
         <p className="animate-bounce font-pixel text-brown">載入中...</p>
@@ -123,6 +137,51 @@ export default function GamePage() {
       {supported && (
         <NotificationPrompt permission={permission} onRequest={requestPermission} />
       )}
+    </div>
+  );
+}
+
+/** 離線時的唯讀遊戲畫面 */
+function OfflineGameView({ pet, navigate }: { pet: import('../types').Pet; navigate: ReturnType<typeof useNavigate> }) {
+  const hungry = isHungry(pet.lastFedAt);
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    navigate('/login', { replace: true });
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center bg-cream px-4 py-6">
+      <div className="mb-4 sm:mb-6 flex w-full max-w-md items-center justify-between">
+        <h1 className="font-pixel text-xs sm:text-sm text-brown-dark">{pet.name}</h1>
+        <PixelButton variant="secondary" onClick={handleLogout} className="!px-3 !py-1 !text-[10px] !border-2">
+          登出
+        </PixelButton>
+      </div>
+
+      <div className="mb-4 flex flex-col items-center">
+        <PixelSprite stage={pet.stage} size="lg" />
+        <p className="mt-3 font-pixel text-xs text-brown">{pet.name}</p>
+        <p className="mt-1 font-pixel text-[10px] text-brown-light">
+          累計餵食 {pet.totalFeedings} 次
+        </p>
+      </div>
+
+      {hungry && (
+        <div className="mb-4 w-full max-w-md animate-pulse border-2 border-red-500 bg-red-100 p-3 text-center font-pixel text-[10px] text-red-700">
+          &#x26A0;&#xFE0F; 電子雞餓了！快來餵食！
+        </div>
+      )}
+
+      <div className="mb-4 grid w-full max-w-md grid-cols-2 gap-2 sm:gap-3">
+        <StatBar icon="❤️" label="生命" value={pet.stats.health} warningThreshold={30} />
+        <StatBar icon="⚡" label="體力" value={pet.stats.stamina} />
+        <StatBar icon="🍽️" label="胃口" value={pet.stats.appetite} />
+        <StatBar icon="📏" label="體型" value={pet.stats.size} />
+      </div>
+
+      <PixelButton disabled className="w-full max-w-md !py-4 !text-sm">
+        📴 離線中，無法餵食
+      </PixelButton>
     </div>
   );
 }

--- a/frontend/src/services/offlineStorage.ts
+++ b/frontend/src/services/offlineStorage.ts
@@ -1,0 +1,28 @@
+import type { Pet } from '../types';
+
+const PET_KEY = 'tamagotchi:pet';
+const SYNC_KEY = 'tamagotchi:lastSync';
+
+export function savePetToCache(pet: Pet): void {
+  localStorage.setItem(PET_KEY, JSON.stringify(pet));
+  localStorage.setItem(SYNC_KEY, new Date().toISOString());
+}
+
+export function getPetFromCache(): Pet | null {
+  const raw = localStorage.getItem(PET_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as Pet;
+  } catch {
+    return null;
+  }
+}
+
+export function removePetFromCache(): void {
+  localStorage.removeItem(PET_KEY);
+  localStorage.removeItem(SYNC_KEY);
+}
+
+export function getLastSyncTime(): string | null {
+  return localStorage.getItem(SYNC_KEY);
+}

--- a/frontend/src/sw-custom.ts
+++ b/frontend/src/sw-custom.ts
@@ -1,12 +1,39 @@
 /// <reference lib="webworker" />
 import { precacheAndRoute } from 'workbox-precaching';
+import { registerRoute } from 'workbox-routing';
+import { NetworkFirst, StaleWhileRevalidate } from 'workbox-strategies';
 
 declare const self: ServiceWorkerGlobalScope;
+
+// 立即接管所有 clients
+self.addEventListener('install', () => {
+  void self.skipWaiting();
+});
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
 
 // Workbox precache manifest injection point
 precacheAndRoute(self.__WB_MANIFEST);
 
-/** 預留 push event handler — 等後端實作後可直接啟用 */
+// Runtime caching: GET /api/pet — NetworkFirst，離線時 fallback 到 cache
+registerRoute(
+  ({ url }) => url.pathname === '/api/pet',
+  new NetworkFirst({
+    cacheName: 'api-pet',
+    networkTimeoutSeconds: 5,
+  }),
+);
+
+// Runtime caching: GET /api/auth/me — StaleWhileRevalidate
+registerRoute(
+  ({ url }) => url.pathname === '/api/auth/me',
+  new StaleWhileRevalidate({
+    cacheName: 'api-auth',
+  }),
+);
+
+/** push event handler */
 self.addEventListener('push', (event) => {
   const data = event.data?.json() ?? {};
   const title = data.title ?? '🍽️ 餵食提醒';

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -8,7 +8,8 @@
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
-    "noEmit": true,
+    "composite": true,
+    "noEmit": false,
     "strict": true
   },
   "include": ["vite.config.ts"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
       },
       manifest: false,
+      devOptions: {
+        enabled: false,
+      },
     }),
   ],
   server: {


### PR DESCRIPTION
## T24 PWA 離線支援

### 完成項目

- ✅ `offlineStorage.ts`：localStorage 快取（tamagotchi:pet, tamagotchi:lastSync）
- ✅ `OfflineBanner`：像素風離線警示 banner，fixed 頂部，顯示最後同步時間
- ✅ `sw-custom.ts`：NetworkFirst / StaleWhileRevalidate runtime caching
- ✅ `client.ts`：response interceptor 自動存 pet；error interceptor 網路錯誤時回傳快取
- ✅ `GamePage`：離線時顯示唯讀畫面或無快取提示
- ✅ `App.tsx`：online/offline 事件監聽，全域 OfflineBanner

### 運作邏輯
- 無網路時開啟 App → 顯示 OfflineBanner + 最後同步的 pet 資料
- API 請求失敗 → 自動 fallback 到 localStorage 快取
- 網路恢復 → 自動重新同步最新資料

### 驗收條件
- [x] 無網路時可開啟 App
- [x] 顯示最後一次同步的屬性狀態

Closes #24