### PR TITLE
feat: T26 Docker Compose 正式環境配置

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,13 @@
+# Production Environment Variables
+# Copy this to .env.production and fill in real values
+
+# Database
+DB_USER=tamagotchi
+DB_PASSWORD=CHANGE_ME_STRONG_PASSWORD
+DB_NAME=tamagotchi
+
+# Backend
+JWT_SECRET=CHANGE_ME_RANDOM_64_CHAR_SECRET
+
+# Frontend (Cloudflare Tunnel URL)
+VITE_API_URL=https://tamagotchi.smart-codings.com/api

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 build/
 *.log
 .DS_Store
+.env.production

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,28 @@
+# ─── Build stage ───
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY package*.json ./
+COPY prisma ./prisma/
+RUN npm ci --ignore-scripts && npx prisma generate
+
+COPY tsconfig.json ./
+COPY src ./src/
+RUN npm run build
+
+# ─── Production stage ───
+FROM node:20-alpine AS production
+WORKDIR /app
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+COPY package*.json ./
+COPY prisma ./prisma/
+RUN npm ci --only=production --ignore-scripts && npx prisma generate
+
+COPY --from=builder /app/dist ./dist/
+
+USER appuser
+EXPOSE 3000
+
+CMD ["node", "dist/index.js"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,54 @@
+version: '3.9'
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: tamagotchi-db
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: tamagotchi-backend
+    environment:
+      DATABASE_URL: postgresql://${DB_USER}:${DB_PASSWORD}@postgres:5432/${DB_NAME}
+      JWT_SECRET: ${JWT_SECRET}
+      PORT: 3000
+      NODE_ENV: production
+      LOG_LEVEL: info
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+    # 不對外暴露，只透過 Cloudflare Tunnel 訪問
+    expose:
+      - "3000"
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_API_URL: ${VITE_API_URL}
+    container_name: tamagotchi-frontend
+    depends_on:
+      - backend
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:80"
+
+volumes:
+  postgres_data:
+    driver: local

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,19 @@
+# ─── Build stage ───
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# ─── Production stage ───
+FROM nginx:alpine AS production
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Service Worker - no cache
+    location /sw.js {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+        expires 0;
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## T26 Docker Compose 正式環境配置

### 完成項目

- ✅ `backend/Dockerfile`: multi-stage build（builder → production），non-root user
- ✅ `frontend/Dockerfile`: Vite build → nginx:alpine
- ✅ `frontend/nginx.conf`: SPA fallback、gzip、static asset cache、SW no-cache
- ✅ `docker-compose.prod.yml`: 正式環境配置（DB 不對外暴露，frontend 綁 127.0.0.1:8080）
- ✅ `.env.production.example`: 環境變數範本

### 驗收條件
- [x] `docker-compose -f docker-compose.prod.yml up -d` 正常啟動
- [x] 資料持久化（postgres_data volume）
- [x] 環境變數配置完整

Closes #26