### PR TITLE
feat: T28 LaunchAgent 開機自啟

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -65,3 +65,26 @@ launchctl list | grep cloudflared-tamagotchi
 # 查看 tunnel log
 tail -f ~/.cloudflared/tamagotchi-tunnel.log
 ```
+
+## LaunchAgent 設定（T28）
+
+LaunchAgent plist 檔案位置：
+
+| 服務 | Plist |
+|------|-------|
+| Docker Compose (app) | `~/Library/LaunchAgents/com.openclaw.tamagotchi.plist` |
+| Cloudflare Tunnel | `~/Library/LaunchAgents/com.openclaw.cloudflared-tamagotchi.plist` |
+
+### 啟動指令
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.openclaw.tamagotchi.plist
+launchctl load ~/Library/LaunchAgents/com.openclaw.cloudflared-tamagotchi.plist
+```
+
+### 停止指令
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.openclaw.tamagotchi.plist
+launchctl unload ~/Library/LaunchAgents/com.openclaw.cloudflared-tamagotchi.plist
+```


### PR DESCRIPTION
## T28 LaunchAgent 開機自啟

### 完成項目
- ✅ `com.openclaw.tamagotchi.plist`: Docker Compose prod 開機自啟
- ✅ `com.openclaw.cloudflared-tamagotchi.plist`: Cloudflare Tunnel 開機自啟
- ✅ `docs/deployment.md` 補充 LaunchAgent 操作說明

### 驗收條件
- [x] 重開機後 `launchctl list` 可見兩個服務
- [x] 服務自動啟動，無需手動操作

Closes #28