### PR TITLE
feat(T26-T28): Docker 正式環境 + Cloudflare Tunnel + LaunchAgent

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,13 +1,17 @@
 # Production Environment Variables
-# Copy this to .env.production and fill in real values
+# 複製此檔為 .env.production 並填入真實值（.env.production 不進 git）
 
-# Database
+# ── Database ────────────────────────────────────────────────────────────────
 DB_USER=tamagotchi
 DB_PASSWORD=CHANGE_ME_STRONG_PASSWORD
 DB_NAME=tamagotchi
 
-# Backend
-JWT_SECRET=CHANGE_ME_RANDOM_64_CHAR_SECRET
+# ── Backend ─────────────────────────────────────────────────────────────────
+# T12 安全審計 H1：JWT_SECRET 必須至少 32 字元
+# 產生範例：openssl rand -base64 48
+JWT_SECRET=CHANGE_ME_RANDOM_64_CHAR_SECRET_AT_LEAST_32_CHARS_REQUIRED
 
-# Frontend (Cloudflare Tunnel URL)
+NODE_ENV=production
+
+# ── Frontend (Cloudflare Tunnel URL) ────────────────────────────────────────
 VITE_API_URL=https://tamagotchi.smart-codings.com/api

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Docker Build & Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # ── JWT_SECRET 長度驗證（T12 安全審計 H1）─────────────────────────────
+      - name: Validate JWT_SECRET length
+        env:
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+        run: |
+          if [[ -z "${JWT_SECRET}" ]]; then
+            echo "::error::JWT_SECRET secret 未設定"
+            exit 1
+          fi
+          if [[ ${#JWT_SECRET} -lt 32 ]]; then
+            echo "::error::JWT_SECRET 長度不足（需 ≥32 字元，目前 ${#JWT_SECRET} 字元）"
+            exit 1
+          fi
+          echo "JWT_SECRET 驗證通過（長度：${#JWT_SECRET}）"
+
+      # ── Backend 測試 ────────────────────────────────────────────────────────
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Run backend tests
+        working-directory: backend
+        env:
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          DATABASE_URL: postgresql://tamagotchi:tamagotchi_pass@localhost:5432/tamagotchi
+          NODE_ENV: test
+        run: npm test
+
+      # ── Frontend 建置測試 ────────────────────────────────────────────────────
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        env:
+          VITE_API_URL: ${{ secrets.VITE_API_URL }}
+        run: npm run build
+
+      # ── 部署到正式伺服器（SSH）─────────────────────────────────────────────
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            cd ${{ secrets.DEPLOY_PATH }}
+            git pull origin main --ff-only
+            bash deploy.sh

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,4 +25,4 @@ COPY --from=builder /app/dist ./dist/
 USER appuser
 EXPOSE 3000
 
-CMD ["node", "dist/index.js"]
+CMD ["sh", "-c", "npx prisma migrate deploy && node dist/index.js"]

--- a/backend/src/plugins/auth.ts
+++ b/backend/src/plugins/auth.ts
@@ -17,6 +17,11 @@ async function authPlugin(
     throw new Error('JWT_SECRET environment variable is not set');
   }
 
+  // T12 安全審計 H1：JWT_SECRET 最少 32 字元
+  if (jwtSecret.length < 32) {
+    throw new Error('JWT_SECRET must be at least 32 characters long');
+  }
+
   fastify.register(fastifyJwt, {
     secret: jwtSecret,
     sign: {

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# deploy.sh - AI Tamagotchi 一鍵部署腳本
+# 使用方式：bash deploy.sh [--pull]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/.env.production"
+ENV_EXAMPLE="${SCRIPT_DIR}/.env.production.example"
+
+# ── 顏色輸出 ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; exit 1; }
+
+# ── 前置檢查 ──────────────────────────────────────────────────────────────────
+command -v docker        >/dev/null 2>&1 || error "docker 未安裝"
+command -v docker compose >/dev/null 2>&1 || error "docker compose 未安裝（需 Docker Compose v2）"
+
+# ── 確認 .env.production 存在 ─────────────────────────────────────────────────
+if [[ ! -f "${ENV_FILE}" ]]; then
+  warn ".env.production 不存在，從 example 複製..."
+  cp "${ENV_EXAMPLE}" "${ENV_FILE}"
+  error "請先編輯 ${ENV_FILE} 填入正式環境參數，再重新執行此腳本"
+fi
+
+# ── JWT_SECRET 長度驗證（T12 H1）───────────────────────────────────────────────
+JWT_SECRET_VAL=$(grep -E '^JWT_SECRET=' "${ENV_FILE}" | cut -d'=' -f2- | tr -d '"' || true)
+if [[ -z "${JWT_SECRET_VAL}" ]]; then
+  error "JWT_SECRET 未設定，請編輯 ${ENV_FILE}"
+fi
+if [[ ${#JWT_SECRET_VAL} -lt 32 ]]; then
+  error "JWT_SECRET 長度不足（需 ≥32 字元，目前 ${#JWT_SECRET_VAL} 字元）"
+fi
+
+# ── 選用：拉取最新程式碼 ──────────────────────────────────────────────────────
+if [[ "${1:-}" == "--pull" ]]; then
+  info "拉取最新程式碼..."
+  git -C "${SCRIPT_DIR}" pull --ff-only
+fi
+
+info "開始建置並啟動服務..."
+
+# ── Docker Compose 部署 ────────────────────────────────────────────────────────
+cd "${SCRIPT_DIR}"
+
+docker compose --env-file "${ENV_FILE}" pull --ignore-pull-failures 2>/dev/null || true
+docker compose --env-file "${ENV_FILE}" build --no-cache
+docker compose --env-file "${ENV_FILE}" up -d --remove-orphans
+
+# ── 等待 backend 健康 ─────────────────────────────────────────────────────────
+info "等待 backend 啟動..."
+RETRIES=30
+until docker compose exec -T backend wget -qO- http://localhost:3000/health >/dev/null 2>&1; do
+  RETRIES=$((RETRIES - 1))
+  [[ ${RETRIES} -le 0 ]] && error "Backend 啟動逾時，請檢查：docker compose logs backend"
+  sleep 2
+done
+
+info "部署完成！服務狀態："
+docker compose ps
+
+info "查看日誌：docker compose logs -f"

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -20,6 +20,19 @@ server {
         expires 0;
     }
 
+    # /api proxy 到後端
+    location /api/ {
+        proxy_pass http://backend:3000/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
     # SPA fallback
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Summary

- **backend/Dockerfile**: 啟動前自動執行 `prisma migrate deploy`，確保 DB schema 最新
- **frontend/nginx.conf**: 補 `/api` proxy 至後端 container（`backend:3000`），完整 SPA + API reverse proxy
- **backend/src/plugins/auth.ts**: JWT_SECRET 最少 32 字元驗證（T12 安全審計 H1 要求）
- **.env.production.example**: 補 `NODE_ENV`、加 JWT_SECRET 最小長度說明及 `openssl rand` 產生指令
- **deploy.sh**: 一鍵部署腳本，含 JWT 長度預檢、docker compose build/up、backend 健康等待
- **.github/workflows/deploy.yml**: push to main 自動觸發 JWT 驗證 → 測試 → build → SSH 部署

## Security

- JWT_SECRET 最少 32 字元驗證在三層強制：`auth.ts`（runtime）、`deploy.sh`（部署前）、`deploy.yml`（CI）

## Test plan

- [ ] 複製 `.env.production.example` → `.env.production`，填入真實值
- [ ] 執行 `bash deploy.sh`，確認服務正常啟動
- [ ] 訪問 `http://localhost/api/health`，確認 nginx proxy 正常
- [ ] 故意設定短 JWT_SECRET（<32 字元），確認 deploy.sh 報錯
- [ ] GitHub Actions deploy.yml 在 push to main 時正確執行