### PR TITLE
fix: frontend Dockerfile 改用 npm install

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci
+RUN npm install
 
 COPY . .
 RUN npm run build


### PR DESCRIPTION
frontend 目錄無獨立 package-lock.json（monorepo 架構），npm ci 失敗。改用 npm install。