### PR TITLE
fix: Prisma schema 補充 datasource url

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -7,6 +7,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 // ========== Enums ==========


### PR DESCRIPTION
prisma migrate deploy 讀不到 DATABASE_URL，因為 schema.prisma 的 datasource 沒有 url 欄位。補充 url = env("DATABASE_URL")。