### PR TITLE
fix: PrismaClient 傳入 datasourceUrl（Prisma v7）

### DIFF
--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -5,7 +5,10 @@ declare global {
   var prisma: PrismaClient | undefined;
 }
 
-export const prisma = global.prisma || new PrismaClient();
+// Prisma v7: datasource url must be passed via constructor (not schema.prisma)
+export const prisma = global.prisma || new PrismaClient({
+  datasourceUrl: process.env.DATABASE_URL,
+});
 
 if (process.env.NODE_ENV !== 'production') {
   global.prisma = prisma;


### PR DESCRIPTION
Prisma v7 的 PrismaClientInitializationError：需要在 constructor 傳入 datasourceUrl: process.env.DATABASE_URL。