### PR TITLE
fix: 用 prisma db push 啟動時同步 schema

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,4 +28,4 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 EXPOSE 3002
 
-CMD ["sh", "-c", "npx prisma migrate deploy && node dist/index.js"]
+CMD ["sh", "-c", "npx prisma db push --skip-generate && node dist/index.js"]


### PR DESCRIPTION
無 prisma/migrations 目錄，migrate deploy 無效。改用 prisma db push --skip-generate 在容器啟動時同步 schema。