### PR TITLE
fix(frontend): api/pet.ts 解構 response wrapper

### DIFF
--- a/frontend/src/api/pet.ts
+++ b/frontend/src/api/pet.ts
@@ -3,23 +3,24 @@ import type { Pet, FeedResult } from '../types';
 
 /** 初始化電子雞（後端自行骰屬性） */
 export async function initPet(name: string): Promise<Pet> {
-  const { data } = await client.post<Pet>('/pet/init', { name });
-  return data;
+  const { data } = await client.post<{ pet: Pet }>('/pet/init', { name });
+  return data.pet;
 }
 
 /** 取得當前電子雞 */
-export async function getPet(): Promise<Pet> {
-  const { data } = await client.get<Pet>('/pet');
-  return data;
+export async function getPet(): Promise<Pet | null> {
+  const { data } = await client.get<{ pet: Pet | null }>('/pet');
+  return data.pet;
 }
 
-/** 餵食電子雞（後端回傳 dice1/dice2，轉換為 dice: [number, number]） */
+/** 餵食電子雞 */
 export async function feedPet(): Promise<FeedResult> {
-  const { data } = await client.post<Omit<FeedResult, 'dice'> & { dice1: number; dice2: number }>('/pet/feed');
+  const { data } = await client.post<{ result: Omit<FeedResult, 'dice'> & { dice?: [number, number]; dice1?: number; dice2?: number } }>('/pet/feed');
+  const r = data.result;
   return {
-    ...data,
-    dice: [data.dice1, data.dice2],
-  };
+    ...r,
+    dice: r.dice ?? [r.dice1 ?? 1, r.dice2 ?? 1],
+  } as FeedResult;
 }
 
 /** 取得今日餵食次數 */


### PR DESCRIPTION
Backend 所有 pet routes 回傳 { pet: ... } 或 { result: ... }，api/pet.ts 未正確解構。