### PR TITLE
fix: T34/T35/T36 Bug Fixes

### DIFF
--- a/frontend/src/api/ai.ts
+++ b/frontend/src/api/ai.ts
@@ -12,6 +12,25 @@ export async function testAiModel(
   apiKey: string,
   model: string,
 ): Promise<TestAiResult> {
-  const res = await client.post<TestAiResult>('/ai/test', { provider, apiKey, model });
-  return res.data;
+  // 加 10 秒 timeout，避免後端還沒實作時一直 loading
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const res = await client.post<TestAiResult>('/ai/test', { provider, apiKey, model }, {
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    return res.data;
+  } catch (err: any) {
+    clearTimeout(timeout);
+    if (err?.name === 'CanceledError' || err?.message?.includes('cancel')) {
+      return { ok: false, error: '連線逾時（10秒），請確認 API 設定是否正確' };
+    }
+    // 解析 axios 錯誤
+    const apiError = err?.response?.data?.error;
+    if (typeof apiError === 'string' && apiError) {
+      return { ok: false, error: apiError };
+    }
+    return { ok: false, error: '測試連線失敗，請檢查 API Key 與模型設定' };
+  }
 }

--- a/frontend/src/hooks/useAIChat.ts
+++ b/frontend/src/hooks/useAIChat.ts
@@ -127,6 +127,7 @@ export default function useAIChat(): AIChatResult {
       // 無 API Key → 靜默跳過
       if (!apiKey || !provider || !model) {
         setMessage(null);
+        setLoading(false);
         return;
       }
 
@@ -138,6 +139,7 @@ export default function useAIChat(): AIChatResult {
           const cooldownMs = getCooldownMs(petHP);
           if (elapsed < cooldownMs) {
             startCooldownTimer(petHP);
+            setLoading(false);
             return;
           }
         }

--- a/frontend/src/pages/FeedPage.tsx
+++ b/frontend/src/pages/FeedPage.tsx
@@ -55,8 +55,14 @@ export default function FeedPage() {
       apiDoneRef.current = true;
       tryShowResult();
     },
-    onError: (err: Error) => {
-      setError(err.message || '餵食失敗，請稍後再試');
+    onError: (err: any) => {
+      // 解析 axios 錯誤訊息，顯示友善中文
+      const apiMessage = err?.response?.data?.error;
+      const friendlyMessage =
+        typeof apiMessage === 'string' && apiMessage.length > 0
+          ? apiMessage
+          : '餵食失敗，請稍後再試';
+      setError(friendlyMessage);
     },
   });
 


### PR DESCRIPTION
## Bug Fixes — T34 / T35 / T36

### T34 (#73) — useAIChat loading 卡住
- 修復：無 API Key 和冷卻中兩個 early return 路徑沒清 loading → 補上 `setLoading(false)`

### T35 (#74) — FeedPage 錯誤訊息不友善
- 修復：error handler 改解析 `error.response?.data?.error`，顯示友善中文提示而非 axios 原始錯誤

### T36 (#75) — 測試連線按鈕逾時處理
- 修復：`testAiModel` 加 AbortController 10 秒逾時
- 逾時時顯示「連線逾時（10秒），請確認 API 設定是否正確」
- 失敗時解析 axios 錯誤訊息顯示給使用者

Closes #73, #74, #75