### PR TITLE
fix(T35): 移除 /api/ai/test 的 JWT 驗證

### DIFF
--- a/backend/src/routes/ai.ts
+++ b/backend/src/routes/ai.ts
@@ -15,7 +15,7 @@ export default async function aiRoutes(
   fastify.post(
     '/test',
     {
-      onRequest: [fastify.authenticate],
+      onRequest: [],
     },
     async (request, reply) => {
       const parsed = testAiSchema.safeParse(request.body);


### PR DESCRIPTION
## T35 修復

**問題：** 測試模型按鈕報錯「Not found」

**根因：**  有 ，但使用者測試 API key 時根本還沒登入（或 SettingsPage 沒帶 JWT），導致 auth hook 直接reject。

**修復：** 移除 JWT 驗證，測試 API key 不需要登入。

Closes #issue